### PR TITLE
9 error when indexing root page

### DIFF
--- a/exporter/index.js
+++ b/exporter/index.js
@@ -33,12 +33,14 @@ const exporter = async (index, newIndex) => {
 
 const saveObjects = (index, objects) => {
   return index
-    .saveObjects(objects)
+    .saveObjects(objects, {
+      autoGenerateObjectIDIfNotExist: true
+    })
     .then(({ objectIDs }) => {
       objectIDs.forEach(objectID => {
         console.info(`${chalk.green(
           '@netlify/plugin-algolia-index:'
-        )} indexing ${chalk.cyan(objectID + '/')}`)
+        )} indexing ${chalk.cyan(objectID)}`)
       });
     })
     .catch(error => {

--- a/parser/index.js
+++ b/parser/index.js
@@ -43,15 +43,16 @@ const processor = unified()
 async function parse(contents, pathToFile, { PUBLISH_DIR, textLength, stopwords }) {
   const { data, contents: text } = await processor.process(vfile({ contents }))
   const from = pathToFile.slice(PUBLISH_DIR.length + 1).split('/').slice(0, -1)
+  const path = `/${from.join('/')}`
 
   return {
-    objectID: from.join('/'),
+    objectID: path,
     text: stopword
       .removeStopwords(text.replace(/(\\n|\W)+/, ' ').trim().split(/\W+/), stopwords)
       .join(' ')
       .substring(0, textLength),
     from: from,
-    path: from.join('/'),
+    path: path,
     ...Object.entries(data).reduce((acc, [k, v]) => ({
       ...acc,
       ...(indexKeys.indexOf(k) !== -1 ? {


### PR DESCRIPTION
fixes #9 by adding the absolute path as a variable before using it and by supporting blank paths using algolia auto-gen object IDs (it shouldn't ever need those though)